### PR TITLE
fixed zos-working-tree-encoding problem

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # encode all files as EBCDIC unless mentioned elsewhere
-*       git-encoding=iso8859-1 working-tree-encoding=ibm-1047
+*       git-encoding=iso8859-1 zos-working-tree-encoding=ibm-1047
 *.bin            binary
 # encode selected files as ASCII
-.gitattributes   git-encoding=iso8859-1 working-tree-encoding=iso8859-1
-.gitignore       git-encoding=iso8859-1 working-tree-encoding=iso8859-1
+.gitattributes   git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1
+.gitignore       git-encoding=iso8859-1 zos-working-tree-encoding=iso8859-1


### PR DESCRIPTION
This PR fixes a problem with the working-tree-encoding parameter which has recently been replaced by zos-working-tree-encoding. working-tree-encoding was originally used by Rocket for code page conversion between the working tree and the remote. Unfortunately, the same parameter name was used in standard git which causes a problem when downloading zip files from github. The zip files incorrectly contain files encoded in EBCDIC with a malformed line ending. 